### PR TITLE
Implement Cross-Platform Compatibility with Unix-based systems.

### DIFF
--- a/honeybee/config.py
+++ b/honeybee/config.py
@@ -31,7 +31,7 @@ class Folders(object):
     __userPath = {
         "pathToRadianceFolder": r" ",
         "pathToEnergyPlusFolder": r" ",
-        "pathToOpenStudioFolder": r'C:\Program Files\OpenStudio 1.11.0',
+        "pathToOpenStudioFolder": r'',
     }
 
     def __init__(self, mute=False):
@@ -64,9 +64,14 @@ class Folders(object):
                 self.perlExePath = __perlFile
 
             # TODO: @sariths we need a method to search and find the executables
-            else:
-                pass
+            elif os.name == 'posix':
+                __radbin, __radFile = self.__which("mkillum")
+                self.radbinPath = __radbin
+
+                __perlpath, __perlFile = self.__which("perl")
+                self.perlExePath = __perlpath
                 # raise NotImplementedError
+
 
     def __which(self, program):
         """Find executable programs.
@@ -81,9 +86,12 @@ class Folders(object):
         def is_exe(fpath):
             # Make sure it's not part of Dive installation as DIVA doesn't
             # follow the standard structure folder for Daysim and Radiance
-            if fpath.upper().find("DIVA"):
+            # Note: (@mostaphaRoudsari, DIVA check is only required for...
+            #...Windows.
+            if fpath.upper().find("DIVA") and os.name == 'nt':
                 return False
             # Return true if file exists and is executable
+
             return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
         # check for the file in all path in environment
@@ -161,6 +169,9 @@ class Folders(object):
         # Search for folders with 'perl' in their names. Hopefully only one exists!
         self.__perlExePath = None
 
+        if os.name == 'posix':
+            return
+
         if not openStudioPath:
             return
 
@@ -197,6 +208,7 @@ epPath = None
 
 perlExePath = f.perlExePath
 """Path to the perl executable needed for some othe Radiance Scripts."""
+
 
 pythonExePath = f.pythonExePath
 """Path to python executable needed for some Radiance scripts from the PyRad

--- a/honeybee/radiance/command/genskyvec.py
+++ b/honeybee/radiance/command/genskyvec.py
@@ -37,8 +37,9 @@ class Genskyvec(RadianceCommand):
     def toRadString(self, relativePath=False):
         # TODO: This only works for Windows for now.
         # Need to make the path lookup thing x-platform.
-        perlPath = self.normspace(self.perlExePath)
-        cmdPath = self.normspace(os.path.join(self.radbinPath,'genskyvec.pl'))
+        perlPath = self.normspace(self.perlExePath) if os.name == 'nt' else ''
+        exeName = 'genskyvec.pl' if os.name == 'nt' else 'genskyvec'
+        cmdPath = self.normspace(os.path.join(self.radbinPath,exeName))
 
         headerSuppress = self.headerSuppress.toRadString()
         skySubDiv = self.skySubdivision.toRadString()

--- a/scripts/Objview.py
+++ b/scripts/Objview.py
@@ -11,7 +11,7 @@ Keywords: Radiance, Objview, Previews
 from honeybee.radiance.command.objview import Objview
 import os
 
-os.chdir(r'..\tests\room')
+os.chdir(r'../tests/room')
 
 objv = Objview()
 objv.sceneFiles = [r"room.mat", "room.rad"]

--- a/scripts/ThreePhaseIllum.py
+++ b/scripts/ThreePhaseIllum.py
@@ -22,7 +22,7 @@ import os
 
 
 
-os.chdir(r'..\tests\room')
+os.chdir(r'../tests/room')
 
 
 def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
@@ -79,7 +79,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
         rflux2 = Rfluxmtx()
         rflux2.samplingRaysCount = 1000
         rflux2.sender = 'glazingI.rad_m'
-        skyFile = rflux2.defaultSkyGround(r'temp\rfluxSky.rad',skyType='r4')
+        skyFile = rflux2.defaultSkyGround(r'temp/rfluxSky.rad',skyType='r4')
         rflux2.receiverFile = skyFile
         rflux2.rfluxmtxParameters = rfluxPara
         rflux2.radFiles = [r"room.mat",
@@ -97,13 +97,13 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
     # Step s: Creating the sky matrix
     if phasesToCalculate['s']:
         if calculationType == 'annual':
-            weaFile = Epw2wea(epwFile=epwFile or 'test.epw', outputWeaFile=r'temp\test.wea')
+            weaFile = Epw2wea(epwFile=epwFile or 'test.epw', outputWeaFile=r'temp/test.wea')
             weaFile.execute()
 
             gendayParam = GendaymtxParameters()
             gendayParam.skyDensity = 4
 
-            genday = Gendaymtx(weaFile=r'temp\test.wea', outputName=r'temp\day.smx')
+            genday = Gendaymtx(weaFile=r'temp/test.wea', outputName=r'temp/day.smx')
             genday.gendaymtxParameters = gendayParam
             genday.execute()
 
@@ -137,7 +137,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
 
     return 'temp/results.txt'
 
-phases={'v':True,'t':True,'d':True,'s':False}
+phases={'v':True,'t':True,'d':True,'s':True}
 tmatrices = ['xmls/clear.xml', 'xmls/diffuse50.xml', 'xmls/ExtVenetianBlind_17tilt.xml']
 
 epwFiles = ['epws/USA_AK_Anchorage.Intl.AP.702730_TMY3.epw',

--- a/scripts/ThreePhaseImage.py
+++ b/scripts/ThreePhaseImage.py
@@ -22,12 +22,12 @@ import os
 
 
 
-os.chdir(r'..\tests\room')
+os.chdir(r'../tests/room')
 
 
 def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
               calculationType='annual',epwFile=None,tmatrixFile=None,
-              hdrResultsFileName=None):
+              hdrResultsFileName=None,numProcessors=1):
 
 
     if phasesToCalculate['v']:
@@ -40,10 +40,10 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
 
         rfluxPara.ad = 65536
         # using this for a quicker run
-        rfluxPara.ad = 1000
+        # rfluxPara.ad = 1000
 
         rfluxPara.lw = 1E-5
-        rfluxPara.lw = 1E-2
+        # rfluxPara.lw = 1E-2
 
 
         #step 1.1 Invert glazing surface with xform so that it faces inwards
@@ -72,7 +72,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
         vwrParaSamp.xResolution = 800
         vwrParaSamp.yResolution = 800
         vwrParaSamp.samplingRaysCount = 9
-        vwrParaSamp.samplingRaysCount = 3
+        # vwrParaSamp.samplingRaysCount = 3
         vwrParaSamp.jitter = 0.7
 
 
@@ -102,6 +102,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
         rflux.outputFilenameFormat = r'temp/%03d.hdr'
         rflux.samplingRaysCount = 9
         rflux.samplingRaysCount = 3
+        rflux.numProcessors = numProcessors
         rflux.execute()
 
     vMatrix = r'temp/vmatrix.vmx'
@@ -122,7 +123,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
         rflux2 = Rfluxmtx()
         rflux2.samplingRaysCount = 1000
         rflux2.sender = 'glazingI.rad_m'
-        skyFile = rflux2.defaultSkyGround(r'temp\rfluxSky.rad',skyType='r4')
+        skyFile = rflux2.defaultSkyGround(r'temp/rfluxSky.rad',skyType='r4')
         rflux2.receiverFile = skyFile
         rflux2.rfluxmtxParameters = rfluxPara
         rflux2.radFiles = [r"room.mat",
@@ -140,13 +141,13 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
     # Step s: Creating the sky matrix
     if phasesToCalculate['s']:
         if calculationType == 'annual':
-            weaFile = Epw2wea(epwFile=epwFile or 'test.epw', outputWeaFile=r'temp\test.wea')
+            weaFile = Epw2wea(epwFile=epwFile or 'test.epw', outputWeaFile=r'temp/test.wea')
             weaFile.execute()
 
             gendayParam = GendaymtxParameters()
             gendayParam.skyDensity = 4
 
-            genday = Gendaymtx(weaFile=r'temp\test.wea', outputName=r'temp\day.smx')
+            genday = Gendaymtx(weaFile=r'temp/test.wea', outputName=r'temp/day.smx')
             genday.gendaymtxParameters = gendayParam
             genday.execute()
 
@@ -182,7 +183,7 @@ def run3phase(phasesToCalculate={'v':True,'t':True,'d':True,'s':True},
 
 
 if __name__ == '__main__':
-    phases = {'v': False, 't': True, 'd': False, 's': False}
+    phases = {'v': True, 't': True, 'd': False, 's': False}
     tmatrices = ['xmls/clear.xml', 'xmls/diffuse50.xml', 'xmls/ExtVenetianBlind_17tilt.xml']
 
     epwFiles = ['epws/USA_AK_Anchorage.Intl.AP.702730_TMY3.epw',
@@ -194,7 +195,8 @@ if __name__ == '__main__':
     for idx, matrix in enumerate(tmatrices):
         resultsFile = run3phase(calculationType='single', tmatrixFile=matrix,
                                phasesToCalculate=phases, epwFile=epwFiles[1],
-                               hdrResultsFileName=r'temp/results%s.hdr' % idx)
+                               hdrResultsFileName=r'temp/results%s.hdr' % idx,
+                                numProcessors=40)
 
         # with open(resultsFile) as results:
         #     for lines in results:

--- a/scripts/TwoPhaseIllum.py
+++ b/scripts/TwoPhaseIllum.py
@@ -18,21 +18,20 @@ from honeybee.radiance.command.gensky import Gensky,GenskyParameters
 
 import os
 
-os.chdir(r'..\tests\room')
+os.chdir(r'../tests/room')
 # Step1: Create annual daylight vectors through epw2wea and gendaymtx.
 
 def run2Phase(calculationType='annual'):
     if calculationType == 'annual':
-        weaFile = Epw2wea(epwFile='test.epw', outputWeaFile=r'temp\test.wea')
+        weaFile = Epw2wea(epwFile='test.epw', outputWeaFile=r'temp/test.wea')
         weaFile.execute()
-
         gendayParam = GendaymtxParameters()
         gendayParam.skyDensity = 4
 
-        genday = Gendaymtx(weaFile=r'temp\test.wea', outputName=r'temp\day.smx')
+        genday = Gendaymtx(weaFile=r'temp/test.wea', outputName=r'temp/day.smx')
         genday.gendaymtxParameters = gendayParam
         genday.execute()
-        skyVector = r'temp\day.smx'
+        skyVector = r'temp/day.smx'
     else:
         gensk = Gensky()
         gensk.monthDayHour = (11, 11, 11)
@@ -56,20 +55,20 @@ def run2Phase(calculationType='annual'):
     rfluxPara.lw = 0.0000001
     rflux = Rfluxmtx()
     rflux.sender = '-'
-    skyFile = rflux.defaultSkyGround(r'temp\rfluxSky.rad',skyType='r4')
+    skyFile = rflux.defaultSkyGround(r'temp/rfluxSky.rad',skyType='r4')
     rflux.receiverFile = skyFile
     rflux.rfluxmtxParameters = rfluxPara
     rflux.radFiles = [r"room.mat",
                       r"room.rad"]
 
     rflux.pointsFile = r"indoor_points.pts"
-    rflux.outputMatrix = r"temp\dayCoeff.dc"
+    rflux.outputMatrix = r"temp/dayCoeff.dc"
     rflux.execute()
 
 
-    mtx1 = Rmtxop(matrixFiles=(os.path.abspath(r'temp\dayCoeff.dc'),
+    mtx1 = Rmtxop(matrixFiles=(os.path.abspath(r'temp/dayCoeff.dc'),
                                os.path.abspath(skyVector)),
-                  outputFile=r'temp\illuminance.tmp')
+                  outputFile=r'temp/illuminance.tmp')
     mtx1.execute()
 
 
@@ -77,11 +76,11 @@ def run2Phase(calculationType='annual'):
     mtx2Param.outputFormat = 'a'
     mtx2Param.combineValues = (47.4, 119.9, 11.6)
     mtx2Param.transposeMatrix = True
-    mtx2 = Rmtxop(matrixFiles=[r'temp\illuminance.tmp'], outputFile=r'temp\illuminance.ill')
+    mtx2 = Rmtxop(matrixFiles=[r'temp/illuminance.tmp'], outputFile=r'temp/illuminance.ill')
     mtx2.rmtxopParameters = mtx2Param
     mtx2.execute()
 
-    with open(r'temp\illuminance.ill') as illFile:
+    with open(r'temp/illuminance.ill') as illFile:
         for lines in illFile:
             try:
                 print(map(float, lines.split()))
@@ -90,4 +89,4 @@ def run2Phase(calculationType='annual'):
 
 #Change the calculationType to 'annual' to run an annual calculation. Any other
 # input will result in a point in type calcualtion using genskyvec.
-run2Phase(calculationType='annual')
+run2Phase(calculationType='single')


### PR DESCRIPTION
1. Made some changes to config.py to fix how radbin paths are searched. Disable DIVA search for unix systems as DIVA is windows only.
2. Modified genskyvec to run on windows and unix-based systems. The major change is in the way perlpath is not required for Unix and also the extension for genskyvec and other perl based binaries such as genBSDF etc do not end with an extension in Unix-based systems.
3. The changes to scripts for objview , three phase etc are minor and only on account of how back slashes and forward slashes work in Windows and Unix.

Below is a 40-core, remote-cluster run on a Red-Hat Linux system. The same script runs on Windows as well but with only one core..:

![8-27-2016 2-37-15 pm](https://cloud.githubusercontent.com/assets/10361848/18029417/9b801ef2-6c65-11e6-85ef-4d5e5bfdafe7.jpg)